### PR TITLE
Added queue label as a third argument to the designated init method

### DIFF
--- a/Source/MABGTimer.h
+++ b/Source/MABGTimer.h
@@ -25,7 +25,7 @@ typedef enum
 }
 
 - (id)initWithObject: (id)obj;
-- (id)initWithObject: (id)obj behavior: (MABGTimerBehavior)behavior;
+- (id)initWithObject: (id)obj behavior: (MABGTimerBehavior)behavior queueLabel:(char const *)queueLabel;
 
 - (void)setTargetQueue: (dispatch_queue_t)target;
 - (void)afterDelay: (NSTimeInterval)delay do: (void (^)(id self))block;

--- a/Source/MABGTimer.h
+++ b/Source/MABGTimer.h
@@ -17,15 +17,15 @@ typedef enum
 
 @interface MABGTimer : NSObject
 {
-    id _obj;
+    __unsafe_unretained id _obj;
     dispatch_queue_t _queue;
     dispatch_source_t _timer;
     MABGTimerBehavior _behavior;
     NSTimeInterval _nextFireTime;
 }
 
-- (id)initWithObject: (id)obj;
-- (id)initWithObject: (id)obj behavior: (MABGTimerBehavior)behavior queueLabel:(char const *)queueLabel;
+- (id)initWithObject:(id)obj;
+- (id)initWithObject:(id)obj behavior: (MABGTimerBehavior)behavior queueLabel:(char const *)queueLabel;
 
 - (void)setTargetQueue: (dispatch_queue_t)target;
 - (void)afterDelay: (NSTimeInterval)delay do: (void (^)(id self))block;

--- a/Source/MABGTimer.m
+++ b/Source/MABGTimer.m
@@ -31,6 +31,16 @@
     return self;
 }
 
+- (void)_cancel
+{
+    if(_timer)
+    {
+        dispatch_source_cancel(_timer);
+        dispatch_release(_timer);
+        _timer = NULL;
+    }
+}    
+
 - (void)_finalize
 {
     [self _cancel];
@@ -50,16 +60,6 @@
     [super dealloc];
 #endif
 }
-
-- (void)_cancel
-{
-    if(_timer)
-    {
-        dispatch_source_cancel(_timer);
-        dispatch_release(_timer);
-        _timer = NULL;
-    }
-}    
 
 - (void)setTargetQueue: (dispatch_queue_t)target
 {

--- a/Source/MABGTimer.m
+++ b/Source/MABGTimer.m
@@ -17,16 +17,16 @@
 
 - (id)initWithObject: (id)obj
 {
-    return [self initWithObject: obj behavior: MABGTimerCoalesce];
+    return [self initWithObject: obj behavior: MABGTimerCoalesce queueLabel:"com.mikeash.MABGTimer"];
 }
 
-- (id)initWithObject: (id)obj behavior: (MABGTimerBehavior)behavior
+- (id)initWithObject: (id)obj behavior: (MABGTimerBehavior)behavior queueLabel:(char const *)queueLabel
 {
     if((self = [super init]))
     {
         _obj = obj;
         _behavior = behavior;
-        _queue = dispatch_queue_create("com.mikeash.MABGTimer", NULL);
+        _queue = dispatch_queue_create(queueLabel, NULL);
     }
     return self;
 }

--- a/Source/MABGTimer.m
+++ b/Source/MABGTimer.m
@@ -31,15 +31,21 @@
     return self;
 }
 
+- (void)_finalize
+{
+    [self _cancel];
+    dispatch_release(_queue);
+}
+
+- (void)finalize
+{
+    [self _finalize];
+    [super finalize];
+}
+
 - (void)dealloc
 {
-    if(_timer)
-    {
-        dispatch_source_cancel(_timer);
-        dispatch_release(_timer);
-    }
-    dispatch_release(_queue);
-	
+    [self _finalize];
 #if !__has_feature(objc_arc) 
     [super dealloc];
 #endif


### PR DESCRIPTION
The queue label is handy for debugging purposes (debugger and crash reports present it), hence made it possible to set it.
