### PR TITLE
Extensions and bug fixes

### DIFF
--- a/Source/MABGTimer.h
+++ b/Source/MABGTimer.h
@@ -10,7 +10,7 @@
 #import <Foundation/Foundation.h>
 
 
-#ifndef mt_dispatch_release
+#ifndef mt_dispatch_strong
     #if TARGET_OS_IPHONE
         #if __IPHONE_OS_VERSION_MIN_REQUIRED >= 60000
             #define mt_dispatch_release(__v)
@@ -19,7 +19,7 @@
             #define mt_dispatch_release(__v) (dispatch_release(__v));
             #define mt_dispatch_strong assign
         #endif
-        #else
+    #else
         #if MAC_OS_X_VERSION_MIN_REQUIRED >= 1080
             #define mt_dispatch_release(__v)
             #define mt_dispatch_strong strong

--- a/Source/MABGTimer.h
+++ b/Source/MABGTimer.h
@@ -9,6 +9,27 @@
 #import <dispatch/dispatch.h>
 #import <Foundation/Foundation.h>
 
+
+#ifndef mt_dispatch_release
+    #if TARGET_OS_IPHONE
+        #if __IPHONE_OS_VERSION_MIN_REQUIRED >= 60000
+            #define mt_dispatch_release(__v)
+            #define mt_dispatch_strong strong
+        #else
+            #define mt_dispatch_release(__v) (dispatch_release(__v));
+            #define mt_dispatch_strong assign
+        #endif
+        #else
+        #if MAC_OS_X_VERSION_MIN_REQUIRED >= 1080
+            #define mt_dispatch_release(__v)
+            #define mt_dispatch_strong strong
+        #else
+            #define mt_dispatch_release(__v) (dispatch_release(__v));
+            #define mt_dispatch_strong assign
+        #endif
+    #endif
+#endif
+
 typedef enum
 {
     MABGTimerCoalesce, // subsequent calls with charged timer can only reduce the time until firing, not extend; default value
@@ -25,7 +46,7 @@ typedef enum
 }
 
 @property (assign) id obj;
-@property (assign, readonly) dispatch_queue_t queue;
+@property (mt_dispatch_strong, readonly) dispatch_queue_t queue;
 
 - (id)initWithObject:(id)obj;
 - (id)initWithObject:(id)obj behavior:(MABGTimerBehavior)behavior queueLabel:(char const *)queueLabel;

--- a/Source/MABGTimer.h
+++ b/Source/MABGTimer.h
@@ -28,7 +28,7 @@ typedef enum
 @property (assign, readonly) dispatch_queue_t queue;
 
 - (id)initWithObject:(id)obj;
-- (id)initWithObject:(id)obj behavior: (MABGTimerBehavior)behavior queueLabel:(char const *)queueLabel;
+- (id)initWithObject:(id)obj behavior:(MABGTimerBehavior)behavior queueLabel:(char const *)queueLabel;
 
 - (void)setTargetQueue: (dispatch_queue_t)target;
 - (void)afterDelay: (NSTimeInterval)delay do: (void (^)(id self))block;

--- a/Source/MABGTimer.h
+++ b/Source/MABGTimer.h
@@ -24,6 +24,9 @@ typedef enum
     NSTimeInterval _nextFireTime;
 }
 
+@property (assign) id obj;
+@property (assign, readonly) dispatch_queue_t queue;
+
 - (id)initWithObject:(id)obj;
 - (id)initWithObject:(id)obj behavior: (MABGTimerBehavior)behavior queueLabel:(char const *)queueLabel;
 

--- a/Source/MABGTimer.m
+++ b/Source/MABGTimer.m
@@ -35,7 +35,7 @@
 
 - (void)_cancel
 {
-    if(_timer)
+    if (_timer)
     {
         dispatch_source_cancel(_timer);
         dispatch_release(_timer);
@@ -46,7 +46,9 @@
 - (void)_finalize
 {
     [self _cancel];
+    
     dispatch_release(_queue);
+    _queue = nil;
 }
 
 - (void)finalize
@@ -88,16 +90,16 @@
         BOOL hasTimer = _timer != nil;
         
         BOOL shouldProceed = NO;
-        if(!hasTimer)
+        if (!hasTimer)
             shouldProceed = YES;
-        else if(_behavior == MABGTimerDelay)
+        else if (_behavior == MABGTimerDelay)
             shouldProceed = YES;
-        else if(_behavior == MABGTimerCoalesce && [self _now] + delay < _nextFireTime)
+        else if (_behavior == MABGTimerCoalesce && [self _now] + delay < _nextFireTime)
             shouldProceed = YES;
         
         if(shouldProceed)
         {
-            if(!hasTimer)
+            if (!hasTimer)
                 _timer = dispatch_source_create(DISPATCH_SOURCE_TYPE_TIMER, 0, 0, _queue);
             dispatch_source_set_timer(_timer, dispatch_time(DISPATCH_TIME_NOW, delay * NSEC_PER_SEC), 0, 0);
             _nextFireTime = [self _now] + delay;
@@ -113,7 +115,8 @@
 
 - (void)performWhileLocked: (dispatch_block_t)block
 {
-    dispatch_sync(_queue, block);
+    if (_queue)
+        dispatch_sync(_queue, block);
 }
 
 - (void)cancel

--- a/Source/MABGTimer.m
+++ b/Source/MABGTimer.m
@@ -38,7 +38,7 @@
     if (_timer)
     {
         dispatch_source_cancel(_timer);
-        dispatch_release(_timer);
+        mt_dispatch_release(_timer);
         _timer = NULL;
     }
 }    
@@ -47,7 +47,7 @@
 {
     [self _cancel];
     
-    dispatch_release(_queue);
+    mt_dispatch_release(_queue);
     _queue = nil;
 }
 

--- a/Source/MABGTimer.m
+++ b/Source/MABGTimer.m
@@ -14,6 +14,8 @@
 
 
 @implementation MABGTimer
+@synthesize obj = _obj;
+@synthesize queue = _queue;
 
 - (id)initWithObject: (id)obj
 {


### PR DESCRIPTION
- 0539db7: Expose queue and object in the public interface so they can be set to nil in the client of MABGTimer.
- 0841501: Fixed a crash in -performWhileLocked: where queue could be nil when the method is called.
- 7cc454d: added ability to compile with iOS6 & OSX 10.8 as minimum target.
